### PR TITLE
resolve type naming collision & exposing all type / interface by default

### DIFF
--- a/src/create-async-options.tsx
+++ b/src/create-async-options.tsx
@@ -1,9 +1,9 @@
 import { createSignal, createResource } from "solid-js";
 
-import { Option } from "./create-select";
+import { RawOption } from "./create-select";
 
-const createAsyncOptions = (
-  fetcher: (inputValue: string) => Promise<Option[]>
+export const createAsyncOptions = (
+  fetcher: (inputValue: string) => Promise<RawOption[]>
 ) => {
   const [inputValue, setInputValue] = createSignal("");
   const [asyncOptions] = createResource(inputValue, fetcher, {
@@ -22,22 +22,24 @@ const createAsyncOptions = (
   };
 };
 
-type variableArgumentLambda = (...args: any[]) => any
+type variableArgumentLambda = (...args: any[]) => any;
 
 /**
  * applies only the last call to lambda that occured within a interval of time [threshhold] in ms, or the first one if no one occured before, default threshold is 250ms, yields a function.
- */ 
- function throttle(fn: variableArgumentLambda, threshhold: number = 250): variableArgumentLambda {
-
+ */
+function throttle(
+  fn: variableArgumentLambda,
+  threshhold: number = 250
+): variableArgumentLambda {
   let last: any, deferTimer: any;
-  return  function(this: any) {
-    const now = +new Date,
-        args = arguments as unknown as any[],
-        ctx = this;
+  return function (this: any) {
+    const now = +new Date(),
+      args = arguments as unknown as any[],
+      ctx = this;
     if (last && now < last + threshhold) {
       // hold on to it
       clearTimeout(deferTimer);
-      deferTimer = setTimeout( () => {
+      deferTimer = setTimeout(() => {
         last = now;
         fn.apply(ctx, args);
       }, threshhold);
@@ -51,16 +53,17 @@ type variableArgumentLambda = (...args: any[]) => any
 /**
  * creates a derivation from AsyncOptions that does not forward all consecutive input event to the fetcher lambda, but only those that occur outside of a specific time interval.
  * This helps to mitigate performance problems due to heavy I/O
- * 
+ *
  * consider the following example of events [A..E]
  * A..100ms..B..150ms..C..300ms..D..50ms..E
  * with a default threshhold of 250ms only Event A..C..E are considered
- * @param fetcher 
- * @param timeout 
- * @returns 
+ * @param fetcher
+ * @param timeout
+ * @returns
  */
-const createThrottledAsyncOptions = (
-  fetcher: (inputValue: string) => Promise<Option[]>, timeout?: number
+export const createThrottledAsyncOptions = (
+  fetcher: (inputValue: string) => Promise<RawOption[]>,
+  timeout?: number
 ) => {
   const [inputValue, setInputValue] = createSignal("");
   const [asyncOptions] = createResource(inputValue, fetcher, {
@@ -78,5 +81,3 @@ const createThrottledAsyncOptions = (
     readonly: false,
   };
 };
-
-export { createAsyncOptions, createThrottledAsyncOptions };

--- a/src/create-options.tsx
+++ b/src/create-options.tsx
@@ -1,24 +1,24 @@
 import { JSXElement } from "solid-js";
 
-import { Value } from "./create-select";
+import { RawValue } from "./create-select";
 import { fuzzyHighlight, fuzzySort } from "./fuzzy";
 
-type Values = Value[];
+export type Values = RawValue[];
 
-interface Option {
+export interface Option {
   label: JSXElement;
-  value: Value;
+  value: RawValue;
   disabled: boolean;
 }
 
-interface CreateOptionsConfig {
+export interface CreateOptionsConfig {
   key?: string;
   filterable?: boolean;
-  createable?: boolean | ((inputValue: string) => Value);
-  disable?: (value: Value) => boolean;
+  createable?: boolean | ((inputValue: string) => RawValue);
+  disable?: (value: RawValue) => boolean;
 }
 
-const createOptions = (
+export const createOptions = (
   values: Values | ((inputValue: string) => Values),
   userConfig?: CreateOptionsConfig
 ) => {
@@ -30,7 +30,7 @@ const createOptions = (
     userConfig || {}
   );
 
-  const getLabel = (value: Value) =>
+  const getLabel = (value: RawValue) =>
     config?.key !== undefined ? value[config.key] : value;
 
   const options = (inputValue: string) => {
@@ -61,7 +61,7 @@ const createOptions = (
       );
 
       if (trimmedValue && !exists) {
-        let value: Value;
+        let value: RawValue;
         if (typeof config.createable === "function") {
           value = config.createable(trimmedValue);
         } else {
@@ -86,7 +86,7 @@ const createOptions = (
 
   const optionToValue = (option: Option) => option.value;
 
-  const format = (item: Option | Value, type: "option" | "value") =>
+  const format = (item: Option | RawValue, type: "option" | "value") =>
     type === "option" ? item.label : getLabel(item);
 
   const isOptionDisabled = (option: Option) => option.disabled;
@@ -103,5 +103,3 @@ const areEqualIgnoringCase = (firstString: string, secondString: string) =>
   firstString.localeCompare(secondString, undefined, {
     sensitivity: "base",
   }) === 0;
-
-export { createOptions };

--- a/src/create-select.tsx
+++ b/src/create-select.tsx
@@ -7,37 +7,37 @@ import {
   on,
 } from "solid-js";
 
-type Option = any;
+export type RawOption = any;
 
-type SingleValue = any;
+export type RawSingleValue = any;
 
-type Value = SingleValue | SingleValue[];
+export type RawValue = RawSingleValue | RawSingleValue[];
 
-interface CreateSelectProps {
-  options: Option[] | ((inputValue: string) => Option[]);
-  initialValue?: Value;
+export interface CreateSelectProps {
+  options: RawOption[] | ((inputValue: string) => RawOption[]);
+  initialValue?: RawValue;
   multiple?: boolean;
   disabled?: boolean;
-  optionToValue?: (option: Option) => SingleValue;
-  isOptionDisabled?: (option: Option) => boolean;
-  onChange?: (value: Value) => void;
+  optionToValue?: (option: RawOption) => RawSingleValue;
+  isOptionDisabled?: (option: RawOption) => boolean;
+  onChange?: (value: RawValue) => void;
   onInput?: (inputValue: string) => void;
   onFocus?: (event: FocusEvent) => void;
   onBlur?: (event: FocusEvent) => void;
 }
 
-const createSelect = (props: CreateSelectProps) => {
+export const createSelect = (props: CreateSelectProps) => {
   const config = mergeProps(
     {
       multiple: false,
       disabled: false,
-      optionToValue: (option: Option): SingleValue => option,
-      isOptionDisabled: (option: Option) => false,
+      optionToValue: (option: RawOption): SingleValue => option,
+      isOptionDisabled: (option: RawOption) => false,
     },
     props
   );
 
-  const parseValue = (value: Value) => {
+  const parseValue = (value: RawValue) => {
     if (config.multiple && Array.isArray(value)) {
       return value;
     } else if (!config.multiple && !Array.isArray(value)) {
@@ -56,7 +56,7 @@ const createSelect = (props: CreateSelectProps) => {
   );
 
   const value = () => (config.multiple ? _value() : _value()[0] || null);
-  const setValue = (value: Value) => _setValue(parseValue(value));
+  const setValue = (value: RawValue) => _setValue(parseValue(value));
   const clearValue = () => _setValue([]);
   const hasValue = () => !!(config.multiple ? value().length : value());
 
@@ -92,7 +92,7 @@ const createSelect = (props: CreateSelectProps) => {
       : () => config.options;
   const optionsCount = () => options().length;
 
-  const pickOption = (option: Option) => {
+  const pickOption = (option: RawOption) => {
     if (config.isOptionDisabled(option)) return;
 
     const value = config.optionToValue(option);
@@ -286,7 +286,7 @@ const createSelect = (props: CreateSelectProps) => {
             return;
           }
           if (config.multiple) {
-            const currentValue = value() as SingleValue[];
+            const currentValue = value() as RawSingleValue[];
             setValue([...currentValue.slice(0, -1)]);
           } else {
             clearValue();
@@ -360,6 +360,3 @@ const createSelect = (props: CreateSelectProps) => {
     listRef,
   };
 };
-
-export { createSelect };
-export type { CreateSelectProps, SingleValue, Value, Option };

--- a/src/fuzzy.tsx
+++ b/src/fuzzy.tsx
@@ -1,12 +1,12 @@
-type FuzzySearchMatch = boolean;
+export type FuzzySearchMatch = boolean;
 
-interface FuzzySearchResult {
+export interface FuzzySearchResult {
   target: string;
   score: number;
   matches: FuzzySearchMatch[];
 }
 
-type FuzzySortResult = (FuzzySearchResult & {
+export type FuzzySortResult = (FuzzySearchResult & {
   item: any;
   index: number;
 })[];
@@ -18,7 +18,10 @@ const SCORING = {
   START: 3,
 };
 
-const fuzzySearch = (value: string, target: string): FuzzySearchResult => {
+export const fuzzySearch = (
+  value: string,
+  target: string
+): FuzzySearchResult => {
   let score = SCORING.NO_MATCH;
   let matches: FuzzySearchMatch[] = [];
 
@@ -66,7 +69,7 @@ const fuzzySearch = (value: string, target: string): FuzzySearchResult => {
   };
 };
 
-const fuzzyHighlight = (
+export const fuzzyHighlight = (
   searchResult: FuzzySearchResult,
   highlighter = (match: string) => <mark>{match}</mark>
 ) => {
@@ -105,7 +108,7 @@ const fuzzyHighlight = (
   );
 };
 
-const fuzzySort = (
+export const fuzzySort = (
   value: string,
   items: any[],
   key?: string
@@ -131,5 +134,3 @@ const fuzzySort = (
 
   return sorted;
 };
-
-export { fuzzySort, fuzzySearch, fuzzyHighlight };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,16 +1,6 @@
 import "virtual:windi.css";
-export { createSelect } from "./create-select";
-export { createOptions } from "./create-options";
-export { createAsyncOptions } from "./create-async-options";
-export { fuzzySort, fuzzySearch, fuzzyHighlight } from "./fuzzy";
-export {
-  Select,
-  Container,
-  Control,
-  Placeholder,
-  SingleValue,
-  MultiValue,
-  Input,
-  List,
-  Option,
-} from "./select";
+export * from "./create-select";
+export * from "./create-options";
+export * from "./create-async-options";
+export * from "./fuzzy";
+export * from "./select";

--- a/src/select.tsx
+++ b/src/select.tsx
@@ -12,14 +12,14 @@ import {
 
 import {
   createSelect,
-  Option as OptionType,
-  Value as ValueType,
+  RawOption,
+  RawValue,
   CreateSelectProps,
 } from "./create-select";
 
-interface CommonProps {
+export interface CommonProps {
   format: (
-    data: OptionType | ValueType,
+    data: RawOption | RawValue,
     type: "option" | "value"
   ) => string | undefined;
   placeholder?: string;
@@ -33,11 +33,11 @@ interface CommonProps {
   emptyPlaceholder?: string;
 }
 
-type SelectReturn = ReturnType<typeof createSelect>;
+export type SelectReturn = ReturnType<typeof createSelect>;
 
-type SelectProps = CreateSelectProps & Partial<CommonProps>;
+export type SelectProps = CreateSelectProps & Partial<CommonProps>;
 
-const Select: Component<SelectProps> = (props) => {
+export const Select: Component<SelectProps> = (props) => {
   const [selectProps, local] = splitProps(
     mergeProps(
       {
@@ -100,7 +100,7 @@ const Select: Component<SelectProps> = (props) => {
         loadingPlaceholder={local.loadingPlaceholder}
         emptyPlaceholder={local.emptyPlaceholder}
       >
-        {(option: OptionType) => (
+        {(option: RawOption) => (
           <Option
             isDisabled={select.isOptionDisabled(option)}
             isFocused={select.isOptionFocused(option)}
@@ -114,12 +114,12 @@ const Select: Component<SelectProps> = (props) => {
   );
 };
 
-type ContainerProps = {
+export type ContainerProps = {
   ref: SelectReturn["containerRef"];
   disabled: SelectReturn["disabled"];
 } & Pick<CommonProps, "class">;
 
-const Container: ParentComponent<ContainerProps> = (props) => {
+export const Container: ParentComponent<ContainerProps> = (props) => {
   return (
     <div
       class={`solid-select-container ${
@@ -133,7 +133,7 @@ const Container: ParentComponent<ContainerProps> = (props) => {
   );
 };
 
-type ControlProps = Omit<CommonProps, "class"> &
+export type ControlProps = Omit<CommonProps, "class"> &
   Pick<
     SelectReturn,
     | "value"
@@ -145,7 +145,7 @@ type ControlProps = Omit<CommonProps, "class"> &
     | "inputRef"
   >;
 
-const Control: Component<ControlProps> = (props) => {
+export const Control: Component<ControlProps> = (props) => {
   const removeValue = (index: number) => {
     const value = props.value;
     props.setValue([...value.slice(0, index), ...value.slice(index + 1)]);
@@ -185,17 +185,19 @@ const Control: Component<ControlProps> = (props) => {
   );
 };
 
-type PlaceholderProps = Pick<CommonProps, "placeholder">;
+export type PlaceholderProps = Pick<CommonProps, "placeholder">;
 
-const Placeholder: ParentComponent<PlaceholderProps> = (props) => {
+export const Placeholder: ParentComponent<PlaceholderProps> = (props) => {
   return <div class="solid-select-placeholder">{props.children}</div>;
 };
 
-const SingleValue: ParentComponent<{}> = (props) => {
+export const SingleValue: ParentComponent<{}> = (props) => {
   return <div class="solid-select-single-value">{props.children}</div>;
 };
 
-const MultiValue: ParentComponent<{ onRemove: () => void }> = (props) => {
+export const MultiValue: ParentComponent<{ onRemove: () => void }> = (
+  props
+) => {
   return (
     <div class="solid-select-multi-value">
       {props.children}
@@ -213,12 +215,12 @@ const MultiValue: ParentComponent<{ onRemove: () => void }> = (props) => {
   );
 };
 
-type InputProps = {
+export type InputProps = {
   ref: SelectReturn["inputRef"];
   disabled: SelectReturn["disabled"];
 } & Pick<CommonProps, "id" | "name" | "autofocus" | "readonly">;
 
-const Input: Component<InputProps> = (props) => {
+export const Input: Component<InputProps> = (props) => {
   return (
     <input
       ref={props.ref}
@@ -244,13 +246,13 @@ const Input: Component<InputProps> = (props) => {
   );
 };
 
-type ListProps = {
+export type ListProps = {
   ref: SelectReturn["listRef"];
-  children: (option: OptionType) => JSXElement;
+  children: (option: RawOption) => JSXElement;
 } & Pick<SelectReturn, "isOpen" | "options"> &
   Pick<CommonProps, "loading" | "loadingPlaceholder" | "emptyPlaceholder">;
 
-const List: Component<ListProps> = (props) => {
+export const List: Component<ListProps> = (props) => {
   return (
     <Show when={props.isOpen}>
       <div ref={props.ref} class="solid-select-list">
@@ -278,13 +280,13 @@ const List: Component<ListProps> = (props) => {
   );
 };
 
-type OptionProps = {
+export type OptionProps = {
   isDisabled: boolean;
   isFocused: boolean;
-  pickOption: [SelectReturn["pickOption"], OptionType];
+  pickOption: [SelectReturn["pickOption"], RawOption];
 };
 
-const Option: ParentComponent<OptionProps> = (props) => {
+export const Option: ParentComponent<OptionProps> = (props) => {
   const scrollIntoViewOnFocus = (element: HTMLDivElement) => {
     createEffect(() => {
       if (props.isFocused) {
@@ -303,16 +305,4 @@ const Option: ParentComponent<OptionProps> = (props) => {
       {props.children}
     </div>
   );
-};
-
-export {
-  Select,
-  Container,
-  Control,
-  Placeholder,
-  SingleValue,
-  MultiValue,
-  Input,
-  List,
-  Option,
 };


### PR DESCRIPTION
Hello Martin,

I was using solid-select on an Astro project and wanted to wrap my select with a custom component to customize the behavior.

I found out that not a lot of types are available by default, which make type-safe wrapping hard to do.

I started exporting all types possible, but stumble upon a type name collision on `Option` and `Value` in `create-select.tsx`

I took the liberty to rename them respectively to `RawOption` and `RawValue` (not sure if the names fit here, I'm open to any suggestion you might have).

Besides of that, this will make creating your own Select component using the `createOptions` primitive a little bit type-safer, as it's now possible to access the different type.

Thanks for your work on solid-dnd & solid-select ❤️