### PR TITLE
Added customizable filter key for flexibility

### DIFF
--- a/src/create-options.tsx
+++ b/src/create-options.tsx
@@ -13,6 +13,7 @@ interface Option {
 
 interface CreateOptionsConfig {
   key?: string;
+  filterKey?:string;
   filterable?: boolean;
   createable?: boolean | ((inputValue: string) => Value);
   disable?: (value: Value) => boolean;
@@ -25,6 +26,7 @@ const createOptions = (
   const config = Object.assign(
     {
       filterable: true,
+      filterKey: 'label',
       disable: () => false,
     },
     userConfig || {}
@@ -46,7 +48,7 @@ const createOptions = (
     });
 
     if (config.filterable && inputValue) {
-      createdOptions = fuzzySort(inputValue, createdOptions, "label").map(
+      createdOptions = fuzzySort(inputValue, createdOptions, config.filterKey).map(
         (result) => ({
           ...result.item,
           label: fuzzyHighlight(result),


### PR DESCRIPTION
This PR adds a new user config for `createOptions` to customize how to run a search on given options. This allows users to add custom `JSX.Element` as labels without worrying about search results.