### PR TITLE
[BUGFIX]: Wrong option gets selected, when the user select an option with the mouse

### DIFF
--- a/src/select.tsx
+++ b/src/select.tsx
@@ -211,6 +211,7 @@ const Input: Component<InputProps> = (props) => {
       tabIndex={0}
       autocomplete="off"
       autocapitalize="none"
+      autoCorrect="off"
       autofocus={props.autofocus}
       readonly={props.readonly}
       disabled={select.disabled}


### PR DESCRIPTION
Wrong option gets selected, when the user select an option with the mouse. Please check issue #48  closes #48