### PR TITLE
Fix typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "exports": {
     ".": {
       "solid": "./dist/source/index.jsx",
+      "types": "./dist/types/index.d.ts",
       "default": "./dist/esm/index.js"
     },
     "./style.css": "./dist/esm/style.css"


### PR DESCRIPTION
Fixes, for me, the TypeScript error:

```
Could not find a declaration file for module '@thisbeyond/solid-select'. '<project>/node_modules/@thisbeyond/solid-select/dist/esm/index.js' implicitly has an 'any' type.
  There are types at '<project>/node_modules/@thisbeyond/solid-select/dist/types/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@thisbeyond/solid-select' library may need to update its package.json or typings.
```

May fix #50 generally, but I don't understand TypeScript well enough to be sure this this is a sufficient fix in all situations.