### PR TITLE
prevent option click from bubbling and causing list re-open

### DIFF
--- a/src/select.tsx
+++ b/src/select.tsx
@@ -301,7 +301,11 @@ const Option: ParentComponent<OptionProps> = (props) => {
       data-disabled={select.isOptionDisabled(props.option)}
       data-focused={select.isOptionFocused(props.option)}
       class="solid-select-option"
-      onClick={() => select.pickOption(props.option)}
+      onClick={(e) => {
+        e.stopPropagation();
+        e.preventDefault();
+        select.pickOption(props.option);
+      }}
     >
       {props.children}
     </div>


### PR DESCRIPTION
clicking on option in list currently causes the list to stay open.  I tracked it down to closing, then bubbling to an onclick on the input that causes it to reopen.

also -- this is a great library. required way less fiddling than other select libs I've used in the past

